### PR TITLE
feat: add more streams acls and option for describe topic acls

### DIFF
--- a/src/main/java/com/devshawn/kafka/gitops/MainCommand.java
+++ b/src/main/java/com/devshawn/kafka/gitops/MainCommand.java
@@ -12,7 +12,7 @@ import java.io.File;
 import java.util.concurrent.Callable;
 
 @Command(name = "kafka-gitops",
-        version = "0.2.8",
+        version = "0.2.9-SNAPSHOT",
         exitCodeOnInvalidInput = 0,
         subcommands = {
                 AccountCommand.class,

--- a/src/main/java/com/devshawn/kafka/gitops/domain/options/GetAclOptions.java
+++ b/src/main/java/com/devshawn/kafka/gitops/domain/options/GetAclOptions.java
@@ -1,0 +1,16 @@
+package com.devshawn.kafka.gitops.domain.options;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.inferred.freebuilder.FreeBuilder;
+
+@FreeBuilder
+@JsonDeserialize(builder = GetAclOptions.Builder.class)
+public interface GetAclOptions {
+
+    String getServiceName();
+
+    Boolean getDescribeAclEnabled();
+
+    class Builder extends GetAclOptions_Builder {
+    }
+}

--- a/src/main/java/com/devshawn/kafka/gitops/domain/state/AbstractService.java
+++ b/src/main/java/com/devshawn/kafka/gitops/domain/state/AbstractService.java
@@ -30,6 +30,19 @@ public abstract class AbstractService {
         return builder;
     }
 
+    public AclDetails.Builder generateDescribeAcl(String topic, Optional<String> principal) {
+        AclDetails.Builder builder = new AclDetails.Builder()
+                .setHost("*")
+                .setName(topic)
+                .setOperation("DESCRIBE")
+                .setPermission("ALLOW")
+                .setPattern("LITERAL")
+                .setType("TOPIC");
+
+        principal.ifPresent(builder::setPrincipal);
+        return builder;
+    }
+
     public AclDetails.Builder generatePrefixedTopicACL(String topic, Optional<String> principal, String operation) {
         AclDetails.Builder builder = new AclDetails.Builder()
                 .setHost("*")
@@ -51,6 +64,19 @@ public abstract class AbstractService {
                 .setPermission("ALLOW")
                 .setPattern("LITERAL")
                 .setType("GROUP");
+
+        principal.ifPresent(builder::setPrincipal);
+        return builder;
+    }
+
+    public AclDetails.Builder generateClusterAcl(Optional<String> principal, String operation) {
+        AclDetails.Builder builder = new AclDetails.Builder()
+                .setHost("*")
+                .setName("kafka-cluster")
+                .setOperation(operation)
+                .setPermission("ALLOW")
+                .setPattern("LITERAL")
+                .setType("CLUSTER");
 
         principal.ifPresent(builder::setPrincipal);
         return builder;

--- a/src/main/java/com/devshawn/kafka/gitops/domain/state/ServiceDetails.java
+++ b/src/main/java/com/devshawn/kafka/gitops/domain/state/ServiceDetails.java
@@ -1,5 +1,6 @@
 package com.devshawn.kafka.gitops.domain.state;
 
+import com.devshawn.kafka.gitops.domain.options.GetAclOptions;
 import com.devshawn.kafka.gitops.domain.state.service.ApplicationService;
 import com.devshawn.kafka.gitops.domain.state.service.KafkaConnectService;
 import com.devshawn.kafka.gitops.domain.state.service.KafkaStreamsService;
@@ -18,7 +19,7 @@ public abstract class ServiceDetails extends AbstractService {
 
     public String type;
 
-    public List<AclDetails.Builder> getAcls(String serviceName) {
+    public List<AclDetails.Builder> getAcls(GetAclOptions options) {
         throw new UnsupportedOperationException("Method getAcls is not implemented.");
     }
 }

--- a/src/main/java/com/devshawn/kafka/gitops/domain/state/service/ApplicationService.java
+++ b/src/main/java/com/devshawn/kafka/gitops/domain/state/service/ApplicationService.java
@@ -1,7 +1,9 @@
 package com.devshawn.kafka.gitops.domain.state.service;
 
+import com.devshawn.kafka.gitops.domain.options.GetAclOptions;
 import com.devshawn.kafka.gitops.domain.state.AclDetails;
 import com.devshawn.kafka.gitops.domain.state.ServiceDetails;
+import com.devshawn.kafka.gitops.util.HelperUtil;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.inferred.freebuilder.FreeBuilder;
@@ -24,12 +26,18 @@ public abstract class ApplicationService extends ServiceDetails {
     public abstract List<String> getConsumes();
 
     @Override
-    public List<AclDetails.Builder> getAcls(String serviceName) {
+    public List<AclDetails.Builder> getAcls(GetAclOptions options) {
         List<AclDetails.Builder> acls = new ArrayList<>();
         getProduces().forEach(topic -> acls.add(generateWriteACL(topic, getPrincipal())));
         getConsumes().forEach(topic -> acls.add(generateReadAcl(topic, getPrincipal())));
+
+        if (options.getDescribeAclEnabled()) {
+            List<String> allTopics = HelperUtil.uniqueCombine(getConsumes(), getProduces());
+            allTopics.forEach(topic -> acls.add(generateDescribeAcl(topic, getPrincipal())));
+        }
+
         if (!getConsumes().isEmpty()) {
-            String groupId = getGroupId().isPresent() ? getGroupId().get() : serviceName;
+            String groupId = getGroupId().isPresent() ? getGroupId().get() : options.getServiceName();
             acls.add(generateConsumerGroupAcl(groupId, getPrincipal(), "READ"));
         }
         return acls;

--- a/src/main/java/com/devshawn/kafka/gitops/domain/state/service/KafkaConnectorDetails.java
+++ b/src/main/java/com/devshawn/kafka/gitops/domain/state/service/KafkaConnectorDetails.java
@@ -1,7 +1,9 @@
 package com.devshawn.kafka.gitops.domain.state.service;
 
+import com.devshawn.kafka.gitops.domain.options.GetAclOptions;
 import com.devshawn.kafka.gitops.domain.state.AbstractService;
 import com.devshawn.kafka.gitops.domain.state.AclDetails;
+import com.devshawn.kafka.gitops.util.HelperUtil;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.inferred.freebuilder.FreeBuilder;
 
@@ -17,10 +19,16 @@ public abstract class KafkaConnectorDetails extends AbstractService {
 
     public abstract List<String> getConsumes();
 
-    public List<AclDetails.Builder> getAcls(String connectorName, Optional<String> principal) {
+    public List<AclDetails.Builder> getAcls(String connectorName, Optional<String> principal, GetAclOptions options) {
         List<AclDetails.Builder> acls = new ArrayList<>();
         getProduces().forEach(topic -> acls.add(generateWriteACL(topic, principal)));
         getConsumes().forEach(topic -> acls.add(generateReadAcl(topic, principal)));
+
+        if (options.getDescribeAclEnabled()) {
+            List<String> allTopics = HelperUtil.uniqueCombine(getConsumes(), getProduces());
+            allTopics.forEach(topic -> acls.add(generateDescribeAcl(topic, principal)));
+        }
+
         if (!getConsumes().isEmpty()) {
             acls.add(generateConsumerGroupAcl(String.format("connect-%s", connectorName), principal, "READ"));
         }

--- a/src/main/java/com/devshawn/kafka/gitops/domain/state/settings/Settings.java
+++ b/src/main/java/com/devshawn/kafka/gitops/domain/state/settings/Settings.java
@@ -13,6 +13,8 @@ public interface Settings {
 
     Optional<SettingsTopics> getTopics();
 
+    Optional<SettingsServices> getServices();
+
     Optional<SettingsFiles> getFiles();
 
     class Builder extends Settings_Builder {

--- a/src/main/java/com/devshawn/kafka/gitops/domain/state/settings/SettingsServices.java
+++ b/src/main/java/com/devshawn/kafka/gitops/domain/state/settings/SettingsServices.java
@@ -1,0 +1,16 @@
+package com.devshawn.kafka.gitops.domain.state.settings;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.inferred.freebuilder.FreeBuilder;
+
+import java.util.Optional;
+
+@FreeBuilder
+@JsonDeserialize(builder = SettingsServices.Builder.class)
+public interface SettingsServices {
+
+    Optional<SettingsServicesAcls> getAcls();
+
+    class Builder extends SettingsServices_Builder {
+    }
+}

--- a/src/main/java/com/devshawn/kafka/gitops/domain/state/settings/SettingsServicesAcls.java
+++ b/src/main/java/com/devshawn/kafka/gitops/domain/state/settings/SettingsServicesAcls.java
@@ -1,0 +1,16 @@
+package com.devshawn.kafka.gitops.domain.state.settings;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.inferred.freebuilder.FreeBuilder;
+
+import java.util.Optional;
+
+@FreeBuilder
+@JsonDeserialize(builder = SettingsServicesAcls.Builder.class)
+public interface SettingsServicesAcls {
+
+    Optional<Boolean> getDescribeTopicEnabled();
+
+    class Builder extends SettingsServicesAcls_Builder {
+    }
+}

--- a/src/main/java/com/devshawn/kafka/gitops/service/ConfluentCloudService.java
+++ b/src/main/java/com/devshawn/kafka/gitops/service/ConfluentCloudService.java
@@ -30,11 +30,12 @@ public class ConfluentCloudService {
         }
     }
 
-    public ServiceAccount createServiceAccount(String name) {
+    public ServiceAccount createServiceAccount(String name, boolean isUser) {
         log.info("Creating service account {} in Confluent Cloud via ccloud tool.", name);
         try {
-            String description = String.format("Service account: %s", name);
-            String result = execCmd(new String[]{"ccloud", "service-account", "create", name, "--description", description, "-o", "json"});
+            String serviceName = isUser ? String.format("user-%s", name) : name;
+            String description = isUser ? String.format("User: %s", name) : String.format("Service account: %s", name);
+            String result = execCmd(new String[]{"ccloud", "service-account", "create", serviceName, "--description", description, "-o", "json"});
             return objectMapper.readValue(result, ServiceAccount.class);
         } catch (IOException ex) {
             throw new ConfluentCloudException(String.format("There was an error creating Confluent Cloud service account: %s.", name));

--- a/src/main/java/com/devshawn/kafka/gitops/util/HelperUtil.java
+++ b/src/main/java/com/devshawn/kafka/gitops/util/HelperUtil.java
@@ -1,0 +1,15 @@
+package com.devshawn.kafka.gitops.util;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+public class HelperUtil {
+
+    public static List<String> uniqueCombine(List<String> listOne, List<String> listTwo) {
+        Set<String> set = new LinkedHashSet<>(listOne);
+        set.addAll(listTwo);
+        return new ArrayList<>(set);
+    }
+}

--- a/src/main/java/com/devshawn/kafka/gitops/util/StateUtil.java
+++ b/src/main/java/com/devshawn/kafka/gitops/util/StateUtil.java
@@ -13,4 +13,11 @@ public class StateUtil {
         }
         return Optional.empty();
     }
+
+    public static boolean isDescribeTopicAclEnabled(DesiredStateFile desiredStateFile) {
+        return desiredStateFile.getSettings().isPresent() && desiredStateFile.getSettings().get().getServices().isPresent()
+                && desiredStateFile.getSettings().get().getServices().get().getAcls().isPresent()
+                && desiredStateFile.getSettings().get().getServices().get().getAcls().get().getDescribeTopicEnabled().isPresent()
+                && desiredStateFile.getSettings().get().getServices().get().getAcls().get().getDescribeTopicEnabled().get();
+    }
 }

--- a/src/test/groovy/com/devshawn/kafka/gitops/PlanCommandIntegrationSpec.groovy
+++ b/src/test/groovy/com/devshawn/kafka/gitops/PlanCommandIntegrationSpec.groovy
@@ -65,7 +65,9 @@ class PlanCommandIntegrationSpec extends Specification {
                 "custom-storage-topic",
                 "custom-storage-topics",
                 "default-replication",
-                "default-replication-multiple"
+                "default-replication-multiple",
+                "describe-topic-acl-disabled",
+                "describe-topic-acl-enabled"
         ]
     }
 

--- a/src/test/groovy/com/devshawn/kafka/gitops/domain/state/ServiceDetailsSpec.groovy
+++ b/src/test/groovy/com/devshawn/kafka/gitops/domain/state/ServiceDetailsSpec.groovy
@@ -1,5 +1,6 @@
 package com.devshawn.kafka.gitops.domain.state
 
+import com.devshawn.kafka.gitops.domain.options.GetAclOptions
 import spock.lang.Specification
 
 class ServiceDetailsSpec extends Specification {
@@ -9,7 +10,7 @@ class ServiceDetailsSpec extends Specification {
         ServiceDetails serviceDetails = new ServiceDetails() {}
 
         when:
-        serviceDetails.getAcls("serviceName")
+        serviceDetails.getAcls(new GetAclOptions.Builder().buildPartial())
 
         then:
         UnsupportedOperationException ex = thrown(UnsupportedOperationException)

--- a/src/test/groovy/com/devshawn/kafka/gitops/domain/state/service/ApplicationServiceSpec.groovy
+++ b/src/test/groovy/com/devshawn/kafka/gitops/domain/state/service/ApplicationServiceSpec.groovy
@@ -1,5 +1,6 @@
 package com.devshawn.kafka.gitops.domain.state.service
 
+import com.devshawn.kafka.gitops.domain.options.GetAclOptions
 import com.devshawn.kafka.gitops.domain.state.AclDetails
 import spock.lang.Specification
 
@@ -14,7 +15,8 @@ class ApplicationServiceSpec extends Specification {
                 .build()
 
         when:
-        List<AclDetails.Builder> result = sut.getAcls("kafka-connect-cluster")
+        List<AclDetails.Builder> result = sut.getAcls(new GetAclOptions.Builder()
+                .setServiceName("application-serivce").setDescribeAclEnabled(false).build())
 
         then:
         result

--- a/src/test/resources/plans/custom-application-id-streams-apply-output.txt
+++ b/src/test/resources/plans/custom-application-id-streams-apply-output.txt
@@ -168,4 +168,32 @@ Applying: [CREATE]
 
 Successfully applied.
 
-[SUCCESS] Apply complete! Resources: 12 created, 0 updated, 0 deleted.
+Applying: [CREATE]
+
++ [ACL] streams-application-12
+	 + resource_name: test-streams
+	 + resource_type: GROUP
+	 + resource_pattern: LITERAL
+	 + resource_principal: User:test
+	 + host: *
+	 + operation: DELETE
+	 + permission: ALLOW
+
+
+Successfully applied.
+
+Applying: [CREATE]
+
++ [ACL] streams-application-13
+	 + resource_name: kafka-cluster
+	 + resource_type: CLUSTER
+	 + resource_pattern: LITERAL
+	 + resource_principal: User:test
+	 + host: *
+	 + operation: DESCRIBE_CONFIGS
+	 + permission: ALLOW
+
+
+Successfully applied.
+
+[SUCCESS] Apply complete! Resources: 14 created, 0 updated, 0 deleted.

--- a/src/test/resources/plans/custom-application-id-streams-plan.json
+++ b/src/test/resources/plans/custom-application-id-streams-plan.json
@@ -156,6 +156,32 @@
                 "permission": "ALLOW"
             },
             "action": "ADD"
+        },
+        {
+            "name": "streams-application-12",
+            "aclDetails": {
+                "name": "test-streams",
+                "type": "GROUP",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "DELETE",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "streams-application-13",
+            "aclDetails": {
+                "name": "kafka-cluster",
+                "type": "CLUSTER",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "DESCRIBE_CONFIGS",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
         }
     ]
 }

--- a/src/test/resources/plans/describe-topic-acl-disabled-plan.json
+++ b/src/test/resources/plans/describe-topic-acl-disabled-plan.json
@@ -1,0 +1,369 @@
+{
+    "topicPlans": [],
+    "aclPlans": [
+        {
+            "name": "normal-application-0",
+            "aclDetails": {
+                "name": "test-topic",
+                "type": "TOPIC",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "WRITE",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "normal-application-1",
+            "aclDetails": {
+                "name": "first-topic",
+                "type": "TOPIC",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "READ",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "normal-application-2",
+            "aclDetails": {
+                "name": "normal-application",
+                "type": "GROUP",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "READ",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "streams-application-0",
+            "aclDetails": {
+                "name": "another-test-topic",
+                "type": "TOPIC",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "WRITE",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "streams-application-1",
+            "aclDetails": {
+                "name": "test-topic",
+                "type": "TOPIC",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "READ",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "streams-application-2",
+            "aclDetails": {
+                "name": "streams-application",
+                "type": "TOPIC",
+                "pattern": "PREFIXED",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "READ",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "streams-application-3",
+            "aclDetails": {
+                "name": "streams-application",
+                "type": "TOPIC",
+                "pattern": "PREFIXED",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "WRITE",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "streams-application-4",
+            "aclDetails": {
+                "name": "streams-application",
+                "type": "TOPIC",
+                "pattern": "PREFIXED",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "DESCRIBE",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "streams-application-5",
+            "aclDetails": {
+                "name": "streams-application",
+                "type": "TOPIC",
+                "pattern": "PREFIXED",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "DELETE",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "streams-application-6",
+            "aclDetails": {
+                "name": "streams-application",
+                "type": "TOPIC",
+                "pattern": "PREFIXED",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "CREATE",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "streams-application-7",
+            "aclDetails": {
+                "name": "streams-application",
+                "type": "TOPIC",
+                "pattern": "PREFIXED",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "ALTER",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "streams-application-8",
+            "aclDetails": {
+                "name": "streams-application",
+                "type": "TOPIC",
+                "pattern": "PREFIXED",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "ALTER_CONFIGS",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "streams-application-9",
+            "aclDetails": {
+                "name": "streams-application",
+                "type": "TOPIC",
+                "pattern": "PREFIXED",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "DESCRIBE_CONFIGS",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "streams-application-10",
+            "aclDetails": {
+                "name": "streams-application",
+                "type": "GROUP",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "READ",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "streams-application-11",
+            "aclDetails": {
+                "name": "streams-application",
+                "type": "GROUP",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "DESCRIBE",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "streams-application-12",
+            "aclDetails": {
+                "name": "streams-application",
+                "type": "GROUP",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "DELETE",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "streams-application-13",
+            "aclDetails": {
+                "name": "kafka-cluster",
+                "type": "CLUSTER",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "DESCRIBE_CONFIGS",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "kafka-connect-application-0",
+            "aclDetails": {
+                "name": "poison-topic",
+                "type": "TOPIC",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "WRITE",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "kafka-connect-application-1",
+            "aclDetails": {
+                "name": "connect-configs-kafka-connect-application",
+                "type": "TOPIC",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "READ",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "kafka-connect-application-2",
+            "aclDetails": {
+                "name": "connect-offsets-kafka-connect-application",
+                "type": "TOPIC",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "READ",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "kafka-connect-application-3",
+            "aclDetails": {
+                "name": "connect-status-kafka-connect-application",
+                "type": "TOPIC",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "READ",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "kafka-connect-application-4",
+            "aclDetails": {
+                "name": "connect-configs-kafka-connect-application",
+                "type": "TOPIC",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "WRITE",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "kafka-connect-application-5",
+            "aclDetails": {
+                "name": "connect-offsets-kafka-connect-application",
+                "type": "TOPIC",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "WRITE",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "kafka-connect-application-6",
+            "aclDetails": {
+                "name": "connect-status-kafka-connect-application",
+                "type": "TOPIC",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "WRITE",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "kafka-connect-application-7",
+            "aclDetails": {
+                "name": "kafka-connect-application",
+                "type": "GROUP",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "READ",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "kafka-connect-application-8",
+            "aclDetails": {
+                "name": "another-test-topic",
+                "type": "TOPIC",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "WRITE",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "kafka-connect-application-9",
+            "aclDetails": {
+                "name": "test-topic",
+                "type": "TOPIC",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "READ",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "kafka-connect-application-10",
+            "aclDetails": {
+                "name": "connect-test-sink",
+                "type": "GROUP",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "READ",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        }
+    ]
+}

--- a/src/test/resources/plans/describe-topic-acl-disabled.yaml
+++ b/src/test/resources/plans/describe-topic-acl-disabled.yaml
@@ -1,0 +1,34 @@
+settings:
+  services:
+    acls:
+      describeTopicEnabled: false
+
+services:
+  normal-application:
+    type: application
+    principal: User:test
+    produces:
+      - test-topic
+    consumes:
+      - first-topic
+
+  streams-application:
+    type: kafka-streams
+    principal: User:test
+    consumes:
+      - test-topic
+    produces:
+      - another-test-topic
+
+  kafka-connect-application:
+    type: kafka-connect
+    principal: User:test
+    produces:
+      - poison-topic
+    connectors:
+      test-source:
+        produces:
+          - another-test-topic
+      test-sink:
+        consumes:
+          - test-topic

--- a/src/test/resources/plans/describe-topic-acl-enabled-plan.json
+++ b/src/test/resources/plans/describe-topic-acl-enabled-plan.json
@@ -1,0 +1,460 @@
+{
+    "topicPlans": [],
+    "aclPlans": [
+        {
+            "name": "normal-application-0",
+            "aclDetails": {
+                "name": "test-topic",
+                "type": "TOPIC",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "WRITE",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "normal-application-1",
+            "aclDetails": {
+                "name": "first-topic",
+                "type": "TOPIC",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "READ",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "normal-application-2",
+            "aclDetails": {
+                "name": "first-topic",
+                "type": "TOPIC",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "DESCRIBE",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "normal-application-3",
+            "aclDetails": {
+                "name": "test-topic",
+                "type": "TOPIC",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "DESCRIBE",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "normal-application-4",
+            "aclDetails": {
+                "name": "normal-application",
+                "type": "GROUP",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "READ",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "streams-application-0",
+            "aclDetails": {
+                "name": "another-test-topic",
+                "type": "TOPIC",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "WRITE",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "streams-application-1",
+            "aclDetails": {
+                "name": "test-topic",
+                "type": "TOPIC",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "READ",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "streams-application-2",
+            "aclDetails": {
+                "name": "test-topic",
+                "type": "TOPIC",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "DESCRIBE",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "streams-application-3",
+            "aclDetails": {
+                "name": "another-test-topic",
+                "type": "TOPIC",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "DESCRIBE",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "streams-application-4",
+            "aclDetails": {
+                "name": "streams-application",
+                "type": "TOPIC",
+                "pattern": "PREFIXED",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "READ",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "streams-application-5",
+            "aclDetails": {
+                "name": "streams-application",
+                "type": "TOPIC",
+                "pattern": "PREFIXED",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "WRITE",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "streams-application-6",
+            "aclDetails": {
+                "name": "streams-application",
+                "type": "TOPIC",
+                "pattern": "PREFIXED",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "DESCRIBE",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "streams-application-7",
+            "aclDetails": {
+                "name": "streams-application",
+                "type": "TOPIC",
+                "pattern": "PREFIXED",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "DELETE",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "streams-application-8",
+            "aclDetails": {
+                "name": "streams-application",
+                "type": "TOPIC",
+                "pattern": "PREFIXED",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "CREATE",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "streams-application-9",
+            "aclDetails": {
+                "name": "streams-application",
+                "type": "TOPIC",
+                "pattern": "PREFIXED",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "ALTER",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "streams-application-10",
+            "aclDetails": {
+                "name": "streams-application",
+                "type": "TOPIC",
+                "pattern": "PREFIXED",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "ALTER_CONFIGS",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "streams-application-11",
+            "aclDetails": {
+                "name": "streams-application",
+                "type": "TOPIC",
+                "pattern": "PREFIXED",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "DESCRIBE_CONFIGS",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "streams-application-12",
+            "aclDetails": {
+                "name": "streams-application",
+                "type": "GROUP",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "READ",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "streams-application-13",
+            "aclDetails": {
+                "name": "streams-application",
+                "type": "GROUP",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "DESCRIBE",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "streams-application-14",
+            "aclDetails": {
+                "name": "streams-application",
+                "type": "GROUP",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "DELETE",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "streams-application-15",
+            "aclDetails": {
+                "name": "kafka-cluster",
+                "type": "CLUSTER",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "DESCRIBE_CONFIGS",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "kafka-connect-application-0",
+            "aclDetails": {
+                "name": "poison-topic",
+                "type": "TOPIC",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "WRITE",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "kafka-connect-application-1",
+            "aclDetails": {
+                "name": "poison-topic",
+                "type": "TOPIC",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "DESCRIBE",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "kafka-connect-application-2",
+            "aclDetails": {
+                "name": "connect-configs-kafka-connect-application",
+                "type": "TOPIC",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "READ",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "kafka-connect-application-3",
+            "aclDetails": {
+                "name": "connect-offsets-kafka-connect-application",
+                "type": "TOPIC",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "READ",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "kafka-connect-application-4",
+            "aclDetails": {
+                "name": "connect-status-kafka-connect-application",
+                "type": "TOPIC",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "READ",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "kafka-connect-application-5",
+            "aclDetails": {
+                "name": "connect-configs-kafka-connect-application",
+                "type": "TOPIC",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "WRITE",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "kafka-connect-application-6",
+            "aclDetails": {
+                "name": "connect-offsets-kafka-connect-application",
+                "type": "TOPIC",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "WRITE",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "kafka-connect-application-7",
+            "aclDetails": {
+                "name": "connect-status-kafka-connect-application",
+                "type": "TOPIC",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "WRITE",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "kafka-connect-application-8",
+            "aclDetails": {
+                "name": "kafka-connect-application",
+                "type": "GROUP",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "READ",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "kafka-connect-application-9",
+            "aclDetails": {
+                "name": "another-test-topic",
+                "type": "TOPIC",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "WRITE",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "kafka-connect-application-10",
+            "aclDetails": {
+                "name": "another-test-topic",
+                "type": "TOPIC",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "DESCRIBE",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "kafka-connect-application-11",
+            "aclDetails": {
+                "name": "test-topic",
+                "type": "TOPIC",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "READ",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "kafka-connect-application-12",
+            "aclDetails": {
+                "name": "test-topic",
+                "type": "TOPIC",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "DESCRIBE",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "kafka-connect-application-13",
+            "aclDetails": {
+                "name": "connect-test-sink",
+                "type": "GROUP",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "READ",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        }
+    ]
+}

--- a/src/test/resources/plans/describe-topic-acl-enabled.yaml
+++ b/src/test/resources/plans/describe-topic-acl-enabled.yaml
@@ -1,0 +1,34 @@
+settings:
+  services:
+    acls:
+      describeTopicEnabled: true
+
+services:
+  normal-application:
+    type: application
+    principal: User:test
+    produces:
+      - test-topic
+    consumes:
+      - first-topic
+
+  streams-application:
+    type: kafka-streams
+    principal: User:test
+    consumes:
+      - test-topic
+    produces:
+      - another-test-topic
+
+  kafka-connect-application:
+    type: kafka-connect
+    principal: User:test
+    produces:
+      - poison-topic
+    connectors:
+      test-source:
+        produces:
+          - another-test-topic
+      test-sink:
+        consumes:
+          - test-topic

--- a/src/test/resources/plans/kafka-streams-service-apply-output.txt
+++ b/src/test/resources/plans/kafka-streams-service-apply-output.txt
@@ -182,4 +182,32 @@ Applying: [CREATE]
 
 Successfully applied.
 
-[SUCCESS] Apply complete! Resources: 13 created, 0 updated, 0 deleted.
+Applying: [CREATE]
+
++ [ACL] streams-application-13
+	 + resource_name: streams-application
+	 + resource_type: GROUP
+	 + resource_pattern: LITERAL
+	 + resource_principal: User:test
+	 + host: *
+	 + operation: DELETE
+	 + permission: ALLOW
+
+
+Successfully applied.
+
+Applying: [CREATE]
+
++ [ACL] streams-application-14
+	 + resource_name: kafka-cluster
+	 + resource_type: CLUSTER
+	 + resource_pattern: LITERAL
+	 + resource_principal: User:test
+	 + host: *
+	 + operation: DESCRIBE_CONFIGS
+	 + permission: ALLOW
+
+
+Successfully applied.
+
+[SUCCESS] Apply complete! Resources: 15 created, 0 updated, 0 deleted.

--- a/src/test/resources/plans/kafka-streams-service-plan.json
+++ b/src/test/resources/plans/kafka-streams-service-plan.json
@@ -169,6 +169,32 @@
                 "permission": "ALLOW"
             },
             "action": "ADD"
+        },
+        {
+            "name": "streams-application-13",
+            "aclDetails": {
+                "name": "streams-application",
+                "type": "GROUP",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "DELETE",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "streams-application-14",
+            "aclDetails": {
+                "name": "kafka-cluster",
+                "type": "CLUSTER",
+                "pattern": "LITERAL",
+                "principal": "User:test",
+                "host": "*",
+                "operation": "DESCRIBE_CONFIGS",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
         }
     ]
 }


### PR DESCRIPTION
- Fixes an issue with kafka-streams not having the right ACLs
- Adds a flag to globally add `DESCRIBE` topic ACLs to `produces/consumes` topics