### PR TITLE
Fix for #43. Excape double quotes in credentials.

### DIFF
--- a/src/main/java/com/devshawn/kafka/gitops/config/KafkaGitopsConfigLoader.java
+++ b/src/main/java/com/devshawn/kafka/gitops/config/KafkaGitopsConfigLoader.java
@@ -68,12 +68,19 @@ public class KafkaGitopsConfigLoader {
             }
 
             String value = String.format("%s required username=\"%s\" password=\"%s\";",
-                    loginModule, username.get(), password.get());
+                    loginModule, escape(username.get()), escape(password.get()));
             config.put(SaslConfigs.SASL_JAAS_CONFIG, value);
         } else if (username.get() != null) {
             throw new MissingConfigurationException("KAFKA_SASL_JAAS_PASSWORD");
         } else if (password.get() != null) {
             throw new MissingConfigurationException("KAFKA_SASL_JAAS_USERNAME");
         }
+    }
+
+    private static String escape(String value) {
+        if (value != null) {
+            return value.replace("\"", "\\\"");
+        }
+        return null;
     }
 }


### PR DESCRIPTION
This should fix #43 

Normally I would have preferred to use Guava's `Escaper` class for this. But it was only available somewhere deep in the shaded part of Freebuilder and I didn't want to add an extra dependency for just this. So I opted for slightly less extensible manual option.