### PR TITLE
fix: added command option to skip acls

### DIFF
--- a/src/main/java/com/devshawn/kafka/gitops/MainCommand.java
+++ b/src/main/java/com/devshawn/kafka/gitops/MainCommand.java
@@ -30,6 +30,9 @@ public class MainCommand implements Callable<Integer> {
     @Option(names = {"--no-delete"}, description = "Disable the ability to delete resources.")
     private boolean deleteDisabled = false;
 
+    @Option(names = {"--skip-acls"}, description = "Do not take ACL into account in the plan file.")
+    private boolean skipAcls = false;
+
     @Option(names = {"-h", "--help"}, usageHelp = true, description = "Display this help message.")
     private boolean helpRequested = false;
 
@@ -63,6 +66,10 @@ public class MainCommand implements Callable<Integer> {
 
     public boolean isDeleteDisabled() {
         return deleteDisabled;
+    }
+
+    public boolean areAclsDisabled() {
+        return skipAcls;
     }
 
     public static void main(String[] args) {

--- a/src/main/java/com/devshawn/kafka/gitops/StateManager.java
+++ b/src/main/java/com/devshawn/kafka/gitops/StateManager.java
@@ -86,7 +86,9 @@ public class StateManager {
     private DesiredPlan generatePlan() {
         DesiredState desiredState = getDesiredState();
         DesiredPlan.Builder desiredPlan = new DesiredPlan.Builder();
-        planManager.planAcls(desiredState, desiredPlan);
+        if (!managerConfig.isSkipAclsDisabled()) {
+            planManager.planAcls(desiredState, desiredPlan);
+        }
         planManager.planTopics(desiredState, desiredPlan);
         return desiredPlan.build();
     }

--- a/src/main/java/com/devshawn/kafka/gitops/cli/AccountCommand.java
+++ b/src/main/java/com/devshawn/kafka/gitops/cli/AccountCommand.java
@@ -45,6 +45,7 @@ public class AccountCommand implements Callable<Integer> {
                 .setVerboseRequested(parent.isVerboseRequested())
                 .setDeleteDisabled(parent.isDeleteDisabled())
                 .setIncludeUnchangedEnabled(false)
+                .setSkipAclsDisabled(false)
                 .setStateFile(parent.getFile())
                 .build();
     }

--- a/src/main/java/com/devshawn/kafka/gitops/cli/AccountCommand.java
+++ b/src/main/java/com/devshawn/kafka/gitops/cli/AccountCommand.java
@@ -45,7 +45,7 @@ public class AccountCommand implements Callable<Integer> {
                 .setVerboseRequested(parent.isVerboseRequested())
                 .setDeleteDisabled(parent.isDeleteDisabled())
                 .setIncludeUnchangedEnabled(false)
-                .setSkipAclsDisabled(false)
+                .setSkipAclsDisabled(parent.areAclsDisabled())
                 .setStateFile(parent.getFile())
                 .build();
     }

--- a/src/main/java/com/devshawn/kafka/gitops/cli/ApplyCommand.java
+++ b/src/main/java/com/devshawn/kafka/gitops/cli/ApplyCommand.java
@@ -24,9 +24,6 @@ public class ApplyCommand implements Callable<Integer> {
             description = "Specify the plan file to use.")
     private File planFile;
 
-    @CommandLine.Option(names = {"--skip-acls"}, description = "Do not take ACL into account in the plan file.")
-    private boolean skipAcls = false;
-
     @CommandLine.ParentCommand
     private MainCommand parent;
 
@@ -57,7 +54,7 @@ public class ApplyCommand implements Callable<Integer> {
                 .setVerboseRequested(parent.isVerboseRequested())
                 .setDeleteDisabled(parent.isDeleteDisabled())
                 .setIncludeUnchangedEnabled(false)
-                .setSkipAclsDisabled(skipAcls)
+                .setSkipAclsDisabled(parent.areAclsDisabled())
                 .setStateFile(parent.getFile())
                 .setNullablePlanFile(planFile)
                 .build();

--- a/src/main/java/com/devshawn/kafka/gitops/cli/ApplyCommand.java
+++ b/src/main/java/com/devshawn/kafka/gitops/cli/ApplyCommand.java
@@ -24,6 +24,9 @@ public class ApplyCommand implements Callable<Integer> {
             description = "Specify the plan file to use.")
     private File planFile;
 
+    @CommandLine.Option(names = {"--skip-acls"}, description = "Do not take ACL into account in the plan file.")
+    private boolean skipAcls = false;
+
     @CommandLine.ParentCommand
     private MainCommand parent;
 
@@ -54,6 +57,7 @@ public class ApplyCommand implements Callable<Integer> {
                 .setVerboseRequested(parent.isVerboseRequested())
                 .setDeleteDisabled(parent.isDeleteDisabled())
                 .setIncludeUnchangedEnabled(false)
+                .setSkipAclsDisabled(skipAcls)
                 .setStateFile(parent.getFile())
                 .setNullablePlanFile(planFile)
                 .build();

--- a/src/main/java/com/devshawn/kafka/gitops/cli/PlanCommand.java
+++ b/src/main/java/com/devshawn/kafka/gitops/cli/PlanCommand.java
@@ -26,6 +26,9 @@ public class PlanCommand implements Callable<Integer> {
     @CommandLine.Option(names = {"--include-unchanged"}, description = "Include unchanged resources in the plan file.")
     private boolean includeUnchanged = false;
 
+    @CommandLine.Option(names = {"--skip-acls"}, description = "Do not take ACL into account in the plan file.")
+    private boolean skipAcls = false;
+
     @CommandLine.ParentCommand
     private MainCommand parent;
 
@@ -59,6 +62,7 @@ public class PlanCommand implements Callable<Integer> {
                 .setDeleteDisabled(parent.isDeleteDisabled())
                 .setIncludeUnchangedEnabled(includeUnchanged)
                 .setStateFile(parent.getFile())
+                .setSkipAclsDisabled(skipAcls)
                 .setNullablePlanFile(outputFile)
                 .build();
     }

--- a/src/main/java/com/devshawn/kafka/gitops/cli/PlanCommand.java
+++ b/src/main/java/com/devshawn/kafka/gitops/cli/PlanCommand.java
@@ -26,9 +26,6 @@ public class PlanCommand implements Callable<Integer> {
     @CommandLine.Option(names = {"--include-unchanged"}, description = "Include unchanged resources in the plan file.")
     private boolean includeUnchanged = false;
 
-    @CommandLine.Option(names = {"--skip-acls"}, description = "Do not take ACL into account in the plan file.")
-    private boolean skipAcls = false;
-
     @CommandLine.ParentCommand
     private MainCommand parent;
 
@@ -62,7 +59,7 @@ public class PlanCommand implements Callable<Integer> {
                 .setDeleteDisabled(parent.isDeleteDisabled())
                 .setIncludeUnchangedEnabled(includeUnchanged)
                 .setStateFile(parent.getFile())
-                .setSkipAclsDisabled(skipAcls)
+                .setSkipAclsDisabled(parent.areAclsDisabled())
                 .setNullablePlanFile(outputFile)
                 .build();
     }

--- a/src/main/java/com/devshawn/kafka/gitops/cli/ValidateCommand.java
+++ b/src/main/java/com/devshawn/kafka/gitops/cli/ValidateCommand.java
@@ -37,6 +37,7 @@ public class ValidateCommand implements Callable<Integer> {
                 .setVerboseRequested(parent.isVerboseRequested())
                 .setDeleteDisabled(parent.isDeleteDisabled())
                 .setIncludeUnchangedEnabled(false)
+                .setSkipAclsDisabled(false)
                 .setStateFile(parent.getFile())
                 .build();
     }

--- a/src/main/java/com/devshawn/kafka/gitops/cli/ValidateCommand.java
+++ b/src/main/java/com/devshawn/kafka/gitops/cli/ValidateCommand.java
@@ -37,7 +37,7 @@ public class ValidateCommand implements Callable<Integer> {
                 .setVerboseRequested(parent.isVerboseRequested())
                 .setDeleteDisabled(parent.isDeleteDisabled())
                 .setIncludeUnchangedEnabled(false)
-                .setSkipAclsDisabled(false)
+                .setSkipAclsDisabled(parent.areAclsDisabled())
                 .setStateFile(parent.getFile())
                 .build();
     }

--- a/src/main/java/com/devshawn/kafka/gitops/config/ManagerConfig.java
+++ b/src/main/java/com/devshawn/kafka/gitops/config/ManagerConfig.java
@@ -16,6 +16,8 @@ public interface ManagerConfig {
 
     boolean isIncludeUnchangedEnabled();
 
+    boolean isSkipAclsDisabled();
+
     File getStateFile();
 
     Optional<File> getPlanFile();


### PR DESCRIPTION
This option is not bugging the delete feature like the closed PR. This fixes #51 
This is simply an option check to by-pass the acl if you don't have any configured