### PR TITLE
feat: ACL defaults for host and permission

### DIFF
--- a/src/main/java/com/devshawn/kafka/gitops/domain/state/AclDetails.java
+++ b/src/main/java/com/devshawn/kafka/gitops/domain/state/AclDetails.java
@@ -1,6 +1,5 @@
 package com.devshawn.kafka.gitops.domain.state;
 
-import com.devshawn.kafka.gitops.exception.ValidationException;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.apache.kafka.common.acl.AccessControlEntry;
 import org.apache.kafka.common.acl.AclBinding;
@@ -10,10 +9,6 @@ import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.ResourcePattern;
 import org.apache.kafka.common.resource.ResourceType;
 import org.inferred.freebuilder.FreeBuilder;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @FreeBuilder
 @JsonDeserialize(builder = AclDetails.Builder.class)
@@ -76,5 +71,9 @@ public abstract class AclDetails {
     }
 
     public static class Builder extends AclDetails_Builder {
+        public Builder() {
+            setPermission(AclPermissionType.ALLOW.name());
+            setHost("*");
+        }
     }
 }

--- a/src/main/java/com/devshawn/kafka/gitops/domain/state/CustomAclDetails.java
+++ b/src/main/java/com/devshawn/kafka/gitops/domain/state/CustomAclDetails.java
@@ -46,6 +46,9 @@ public abstract class CustomAclDetails {
     }
 
     public static class Builder extends CustomAclDetails_Builder {
-
+        public Builder() {
+            setPermission(AclPermissionType.ALLOW.name());
+            setHost("*");
+        }
     }
 }


### PR DESCRIPTION
Avoid setting on each and every ACL rule:
```
host: *
permission: ALLOW
```
They are set by default and can be overridden