### PR TITLE
Allow for skipping topic management

### DIFF
--- a/src/main/java/com/devshawn/kafka/gitops/MainCommand.java
+++ b/src/main/java/com/devshawn/kafka/gitops/MainCommand.java
@@ -33,6 +33,9 @@ public class MainCommand implements Callable<Integer> {
     @Option(names = {"--skip-acls"}, description = "Do not take ACLs into account during plans or applies.")
     private boolean skipAcls = false;
 
+    @Option(names = {"--skip-topics"}, description = "Do not take topics into account during plans or applies.")
+    private boolean skipTopics = false;
+
     @Option(names = {"-h", "--help"}, usageHelp = true, description = "Display this help message.")
     private boolean helpRequested = false;
 
@@ -70,6 +73,10 @@ public class MainCommand implements Callable<Integer> {
 
     public boolean areAclsDisabled() {
         return skipAcls;
+    }
+
+    public boolean areTopicsDisabled() {
+        return skipTopics;
     }
 
     public static void main(String[] args) {

--- a/src/main/java/com/devshawn/kafka/gitops/StateManager.java
+++ b/src/main/java/com/devshawn/kafka/gitops/StateManager.java
@@ -79,7 +79,7 @@ public class StateManager {
     public DesiredPlan plan() {
         DesiredPlan desiredPlan = generatePlan();
         planManager.writePlanToFile(desiredPlan);
-        planManager.validatePlanHasChanges(desiredPlan, managerConfig.isDeleteDisabled(), managerConfig.isSkipAclsDisabled());
+        planManager.validatePlanHasChanges(desiredPlan, managerConfig.isDeleteDisabled(), managerConfig.isSkipAclsDisabled(), managerConfig.isSkipTopicsDisabled());
         return desiredPlan;
     }
 
@@ -89,7 +89,9 @@ public class StateManager {
         if (!managerConfig.isSkipAclsDisabled()) {
             planManager.planAcls(desiredState, desiredPlan);
         }
-        planManager.planTopics(desiredState, desiredPlan);
+        if (!managerConfig.isSkipTopicsDisabled()) {
+            planManager.planTopics(desiredState, desiredPlan);
+        }
         return desiredPlan.build();
     }
 
@@ -99,7 +101,7 @@ public class StateManager {
             desiredPlan = generatePlan();
         }
 
-        planManager.validatePlanHasChanges(desiredPlan, managerConfig.isDeleteDisabled(), managerConfig.isSkipAclsDisabled());
+        planManager.validatePlanHasChanges(desiredPlan, managerConfig.isDeleteDisabled(), managerConfig.isSkipAclsDisabled(), managerConfig.isSkipTopicsDisabled());
 
         applyManager.applyTopics(desiredPlan);
         if (!managerConfig.isSkipAclsDisabled()) {

--- a/src/main/java/com/devshawn/kafka/gitops/cli/AccountCommand.java
+++ b/src/main/java/com/devshawn/kafka/gitops/cli/AccountCommand.java
@@ -46,6 +46,7 @@ public class AccountCommand implements Callable<Integer> {
                 .setDeleteDisabled(parent.isDeleteDisabled())
                 .setIncludeUnchangedEnabled(false)
                 .setSkipAclsDisabled(parent.areAclsDisabled())
+                .setSkipTopicsDisabled(parent.areTopicsDisabled())
                 .setStateFile(parent.getFile())
                 .build();
     }

--- a/src/main/java/com/devshawn/kafka/gitops/cli/ApplyCommand.java
+++ b/src/main/java/com/devshawn/kafka/gitops/cli/ApplyCommand.java
@@ -34,7 +34,7 @@ public class ApplyCommand implements Callable<Integer> {
             ParserService parserService = new ParserService(parent.getFile());
             StateManager stateManager = new StateManager(generateStateManagerConfig(), parserService);
             DesiredPlan desiredPlan = stateManager.apply();
-            LogUtil.printApplyOverview(PlanUtil.getOverview(desiredPlan, parent.isDeleteDisabled(), parent.areAclsDisabled()));
+            LogUtil.printApplyOverview(PlanUtil.getOverview(desiredPlan, parent.isDeleteDisabled(), parent.areAclsDisabled(), parent.areTopicsDisabled()));
             return 0;
         } catch (PlanIsUpToDateException ex) {
             LogUtil.printNoChangesMessage();
@@ -55,6 +55,7 @@ public class ApplyCommand implements Callable<Integer> {
                 .setDeleteDisabled(parent.isDeleteDisabled())
                 .setIncludeUnchangedEnabled(false)
                 .setSkipAclsDisabled(parent.areAclsDisabled())
+                .setSkipTopicsDisabled(parent.areTopicsDisabled())
                 .setStateFile(parent.getFile())
                 .setNullablePlanFile(planFile)
                 .build();

--- a/src/main/java/com/devshawn/kafka/gitops/cli/PlanCommand.java
+++ b/src/main/java/com/devshawn/kafka/gitops/cli/PlanCommand.java
@@ -36,7 +36,7 @@ public class PlanCommand implements Callable<Integer> {
             ParserService parserService = new ParserService(parent.getFile());
             StateManager stateManager = new StateManager(generateStateManagerConfig(), parserService);
             DesiredPlan desiredPlan = stateManager.plan();
-            LogUtil.printPlan(desiredPlan, parent.isDeleteDisabled(), parent.areAclsDisabled());
+            LogUtil.printPlan(desiredPlan, parent.isDeleteDisabled(), parent.areAclsDisabled(), parent.areTopicsDisabled());
             return 0;
         } catch (PlanIsUpToDateException ex) {
             LogUtil.printNoChangesMessage();
@@ -60,6 +60,7 @@ public class PlanCommand implements Callable<Integer> {
                 .setIncludeUnchangedEnabled(includeUnchanged)
                 .setStateFile(parent.getFile())
                 .setSkipAclsDisabled(parent.areAclsDisabled())
+                .setSkipTopicsDisabled(parent.areTopicsDisabled())
                 .setNullablePlanFile(outputFile)
                 .build();
     }

--- a/src/main/java/com/devshawn/kafka/gitops/cli/ValidateCommand.java
+++ b/src/main/java/com/devshawn/kafka/gitops/cli/ValidateCommand.java
@@ -38,6 +38,7 @@ public class ValidateCommand implements Callable<Integer> {
                 .setDeleteDisabled(parent.isDeleteDisabled())
                 .setIncludeUnchangedEnabled(false)
                 .setSkipAclsDisabled(parent.areAclsDisabled())
+                .setSkipTopicsDisabled(parent.areTopicsDisabled())
                 .setStateFile(parent.getFile())
                 .build();
     }

--- a/src/main/java/com/devshawn/kafka/gitops/config/ManagerConfig.java
+++ b/src/main/java/com/devshawn/kafka/gitops/config/ManagerConfig.java
@@ -18,6 +18,8 @@ public interface ManagerConfig {
 
     boolean isSkipAclsDisabled();
 
+    boolean isSkipTopicsDisabled();
+
     File getStateFile();
 
     Optional<File> getPlanFile();

--- a/src/main/java/com/devshawn/kafka/gitops/manager/PlanManager.java
+++ b/src/main/java/com/devshawn/kafka/gitops/manager/PlanManager.java
@@ -173,8 +173,8 @@ public class PlanManager {
         });
     }
 
-    public void validatePlanHasChanges(DesiredPlan desiredPlan, boolean deleteDisabled, boolean skipAclsDisabled) {
-        PlanOverview planOverview = PlanUtil.getOverview(desiredPlan, deleteDisabled, skipAclsDisabled);
+    public void validatePlanHasChanges(DesiredPlan desiredPlan, boolean deleteDisabled, boolean skipAclsDisabled, boolean skipTopicsDisabled) {
+        PlanOverview planOverview = PlanUtil.getOverview(desiredPlan, deleteDisabled, skipAclsDisabled, skipTopicsDisabled);
         if (planOverview.getAdd() == 0 && planOverview.getUpdate() == 0 && planOverview.getRemove() == 0) {
             throw new PlanIsUpToDateException();
         }

--- a/src/main/java/com/devshawn/kafka/gitops/util/LogUtil.java
+++ b/src/main/java/com/devshawn/kafka/gitops/util/LogUtil.java
@@ -14,8 +14,8 @@ import picocli.CommandLine;
 
 public class LogUtil {
 
-    public static void printPlan(DesiredPlan desiredPlan, boolean deleteDisabled, boolean skipAclsDisabled) {
-        PlanOverview planOverview = PlanUtil.getOverview(desiredPlan, deleteDisabled, skipAclsDisabled);
+    public static void printPlan(DesiredPlan desiredPlan, boolean deleteDisabled, boolean skipAclsDisabled, boolean skipTopicsDisabled) {
+        PlanOverview planOverview = PlanUtil.getOverview(desiredPlan, deleteDisabled, skipAclsDisabled, skipTopicsDisabled);
 
         printLegend(planOverview);
 
@@ -25,7 +25,7 @@ public class LogUtil {
         printAclOverview(desiredPlan, deleteDisabled);
         desiredPlan.getAclPlans().forEach(LogUtil::printAclPlan);
 
-        printOverview(desiredPlan, deleteDisabled, skipAclsDisabled);
+        printOverview(desiredPlan, deleteDisabled, skipAclsDisabled, skipTopicsDisabled);
     }
 
     public static void printValidationResult(String message, boolean success) {
@@ -131,8 +131,8 @@ public class LogUtil {
      * Helpers
      */
 
-    private static void printOverview(DesiredPlan desiredPlan, boolean deleteDisabled, boolean skipAclsDisabled) {
-        PlanOverview planOverview = PlanUtil.getOverview(desiredPlan, deleteDisabled, skipAclsDisabled);
+    private static void printOverview(DesiredPlan desiredPlan, boolean deleteDisabled, boolean skipAclsDisabled, boolean skipTopicsDisabled) {
+        PlanOverview planOverview = PlanUtil.getOverview(desiredPlan, deleteDisabled, skipAclsDisabled, skipTopicsDisabled);
         System.out.println(String.format("%s: %s, %s, %s.", bold("Plan"), toCreate(planOverview.getAdd()),
                 toUpdate(planOverview.getUpdate()), toDelete(planOverview.getRemove())));
     }

--- a/src/main/java/com/devshawn/kafka/gitops/util/PlanUtil.java
+++ b/src/main/java/com/devshawn/kafka/gitops/util/PlanUtil.java
@@ -9,11 +9,14 @@ import java.util.EnumSet;
 
 public class PlanUtil {
 
-    public static PlanOverview getOverview(DesiredPlan desiredPlan, boolean deleteDisabled, boolean skipAclsDisabled) {
+    public static PlanOverview getOverview(DesiredPlan desiredPlan, boolean deleteDisabled, boolean skipAclsDisabled, boolean skipTopicsDisabled) {
         EnumMap<PlanAction, Long> map = getPlanActionMap();
         desiredPlan.getTopicPlans().forEach(it -> addToMap(map, it.getAction(), deleteDisabled));
         if(!skipAclsDisabled) {
             desiredPlan.getAclPlans().forEach(it -> addToMap(map, it.getAction(), deleteDisabled));
+        }
+        if(!skipAclsDisabled) {
+            desiredPlan.getTopicPlans().forEach(it -> addToMap(map, it.getAction(), deleteDisabled));
         }
         return buildPlanOverview(map);
     }


### PR DESCRIPTION
This allows for the management of only ACLs and not topics. We've got a couple of reasons for needing this:
- We're slowly rolling out ACL and topic management across our various kafka clusters. We're starting with ACLs, and kafka-gitops keeps trying to delete all of our topics as we set this up
- Many of our topics are automatically generated (ksqldb, flink, some in-house applications). Deleting those topics when we try to set up ACLs, or even other topics, would not be ideal.

I opened #79 for discussion, but copying #54 seemed simple enough that I thought I'd give it a shot.